### PR TITLE
required-fields

### DIFF
--- a/resources/views/portfolios/create.blade.php
+++ b/resources/views/portfolios/create.blade.php
@@ -18,8 +18,8 @@
                     <div>
                         <form action="{{route('portfolio.store')}}" method="POST">
                             @csrf
-                            <input type="text" name="title" placeholder="Título para portifólio" class="w-full rounded-lg mb-5">
-                            <textarea name="description" id="description" class="w-full rounded-lg" placeholder="Descrição para Portifólio"></textarea>
+                            <input required type="text" name="title" placeholder="Título para portifólio" class="w-full rounded-lg mb-5">
+                            <textarea required name="description" id="description" class="w-full rounded-lg" placeholder="Descrição para Portifólio"></textarea>
                             <div class="text-right">
                                 <button type="submit" class=" bg-green-500 text-white py-1 px-3 hover:bg-green-700 rounded-lg btn">Salvar</button>
                                 <button type="reset" class=" bg-gray-500 text-white py-1 px-3 hover:bg-gray-700 rounded-lg btn">Cancelar</button>

--- a/resources/views/portfolios/edit.blade.php
+++ b/resources/views/portfolios/edit.blade.php
@@ -20,8 +20,8 @@
                             @csrf
                             @method('PUT')
                             <input type="hidden" name="id" value="{{$portfolio->id}}">
-                            <input type="text" name="title" placeholder="Título para portifólio" class="w-full rounded-lg mb-5" value="{{$portfolio->title}}">
-                            <textarea name="description" id="description" class="w-full rounded-lg" placeholder="Descrição para Portifólio">{{$portfolio->description}}</textarea>
+                            <input required type="text" name="title" placeholder="Título para portifólio" class="w-full rounded-lg mb-5" value="{{$portfolio->title}}">
+                            <textarea required name="description" id="description" class="w-full rounded-lg" placeholder="Descrição para Portifólio">{{$portfolio->description}}</textarea>
                             <div class="text-right">
                                 <button type="submit" class=" bg-green-500 text-white py-1 px-3 hover:bg-green-700 rounded-lg btn">Salvar</button>
                                 <button type="reset" class=" bg-gray-500 text-white py-1 px-3 hover:bg-gray-700 rounded-lg btn">Cancelar</button>


### PR DESCRIPTION
Ao tentar criar um portfolio o usuário pode inadvertidamente deixar de preencher os campos de título e descrição, o que resulta num erro semelhante a este:

SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'description' cannot be null (Connection: mysql, SQL: insert into `portfolios` (`title`, `description`, `token`, `user_id`, `updated_at`, `created_at`) values (test, ?, aa12d5d0-56df-4f83-b983-0a1db2f1804c, 4, 2024-12-09 01:12:44, 2024-12-09 01:12:44)) 

Tornei os campos obrigatórios no client side, mas cabe uma validação via php também.